### PR TITLE
Load Analytics script only under production environment. https://trel…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@ desc "Generate static files"
 task :generate do
   Jekyll::Site.new(Jekyll.configuration({
     "source"      => ".",
-    "destination" => "_site"
+    "destination" => "_site",
+    "config"      => %w(_config.yml _config_pro.yml)
   })).process
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ exclude: [
   'Gemfile', 'Gemfile.lock', 'startup-grind-bcn.sublime-project',
   'startup-grind-bcn.sublime-workspace', 'config', 'bundle', 'Rakefile'
 ]
+environment: development
 assets:
   js_compressor: uglifier
   css_compressor: yui

--- a/_config_pro.yml
+++ b/_config_pro.yml
@@ -1,0 +1,1 @@
+environment: production

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -114,6 +114,8 @@
         </div>
       </div>
     </footer>
-    {% include analytics.html %}
+    {% if site.environment == 'production' %}
+      {% include analytics.html %}
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
…lo.com/c/o8oYEZII/105-review-google-analytics-stuff

Add environment variable to _config.yml with development value and "_config_pro.yml" file with production value.

The _config_pro file is only loaded by generate/publish task to overwrite the default environment variable (development).
